### PR TITLE
docs: Fix a few typos

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-This repo was managed by 'Roberto Rosario' previously who has recentlty removed it from his profile. [here is the link to what he has to say about it ](https://gitlab.com/rosarior/awesome-django) so the credit of this great initiative goes to him. ofcourse for the greater good of community someone has to maintain the repo I have decided to take it further from this commit onwards. community support is always great to have. if you people know some of the packages/tools please do add them to the repo and create the PR.
+This repo was managed by 'Roberto Rosario' previously who has recently removed it from his profile. [here is the link to what he has to say about it ](https://gitlab.com/rosarior/awesome-django) so the credit of this great initiative goes to him. ofcourse for the greater good of community someone has to maintain the repo I have decided to take it further from this commit onwards. community support is always great to have. if you people know some of the packages/tools please do add them to the repo and create the PR.
 
 
 License details added by 'Roberto Rosario':

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ phone numbers.
 
 * [CodingforEntrepreneur](https://www.codingforentrepreneurs.com/projects/) - One of the best collection of Django Videos and all the projects are written in Django.
 * [Code School - Try Django](https://www.codeschool.com/courses/try-django) - An introduction to the basics of Django.
-* [GoDjango](https://godjango.com) - Django videos from basics to advanced. Covering 3rd party apps to core Django compontents.
+* [GoDjango](https://godjango.com) - Django videos from basics to advanced. Covering 3rd party apps to core Django components.
 * [Must Watch Django Videos](https://gitlab.com/rosarior/django-must-watch) - Must-watch videos about Django. (or about Python as applied to Django)
 
 # Utilities


### PR DESCRIPTION
There are small typos in:
- LICENSE.md
- README.md

Fixes:
- Should read `recently` rather than `recentlty`.
- Should read `components` rather than `compontents`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md