### PR TITLE
replace django-q with django-q2

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ phone numbers.
 *Packages that make working with task/background queues easier.*
 
 * [django-celery](http://celery.github.io/django-celery/) - Celery Integration for Django. (no longer required for Celery 3.1 and up)
-* [django-q](https://github.com/Koed00/django-q) - A native multiprocessing task queue for Django.
+* [django-q2](https://github.com/django-q2/django-q2) A multiprocessing distributed task queue for Django based on Django-Q.
 * [django-rq](https://github.com/rq/django-rq) - The easiest way to monitor and use [RQ](http://python-rq.org) in your Django projects.
 * [huey](https://github.com/coleifer/huey/) - A little multi-threaded task queue for python.
 


### PR DESCRIPTION
django-q2 is a fork of django-q. Development stalled in June 2021 and this is maintained regularly.