### PR TITLE
Add Apitally to RESTful API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ phone numbers.
 * [django-tastypie](http://tastypieapi.org/) - Creating delicious APIs for Django apps since 2010.
 * [restless](https://github.com/toastdriven/restless/) - A lightweight REST miniframework for Python.
 * [djangorestframework-recursive](https://github.com/heywbj/django-rest-framework-recursive/) - Recursive Serialization for Django REST framework.
+* [apitally](https://github.com/apitally/apitally-py) - Simple API monitoring, analytics, and request logging for Django REST Framework and Django Ninja.
 
 ## Search
 


### PR DESCRIPTION
Add [Apitally](https://github.com/apitally/apitally-py) to the RESTful API section.

Apitally is a lightweight monitoring and analytics tool that helps developers track API usage, performance, and errors with minimal setup. It also includes request logging and alerting features.

Supports Django REST Framework and Django Ninja. See setup guides here:
https://docs.apitally.io/frameworks/django-rest-framework
https://docs.apitally.io/frameworks/django-ninja